### PR TITLE
Fixes crash when attribute exists with value 'None'

### DIFF
--- a/src/brasil/gov/vcge/dx/widget.py
+++ b/src/brasil/gov/vcge/dx/widget.py
@@ -90,7 +90,9 @@ class SkosWidget(widget.SequenceWidget):
 
     @property
     def existing(self):
-        value = getattr(self.context, 'skos', [])
+        value = getattr(self.context, 'skos', None)
+        if value is None:
+            value = []
         terms = self.vocab()
         data = []
         for token in value:


### PR DESCRIPTION
In the hypothetical situation an object happened to have the "scons" attribute with a non iterable value, like None, which could hipothetically happen when importing content to a Plone site with this product installed -  the former line 93 would retrieve the non iterable, though improbable, and line 96 would generate an exquisite exception.

Not that I am saying that this could happen  - but we better be prepared.
