### PR TITLE
The page is prevented from rendering if there is an incorrect VCGE term - even for borderline definitions of "incorrect"

### DIFF
--- a/src/brasil/gov/vcge/dx/widget.py
+++ b/src/brasil/gov/vcge/dx/widget.py
@@ -94,7 +94,7 @@ class SkosWidget(widget.SequenceWidget):
         value = None
         if base_hasattr(self.context, 'skos'):
             value = getattr(self.context, 'skos')
-        if not value:
+        if value is None:
             value = []
         terms = self.vocab()
         data = []


### PR DESCRIPTION
This should be merged in for planalto.gov.br to go live. I am manually commiting the change in the homologation copy for now.
